### PR TITLE
Feature/in 632 password validation

### DIFF
--- a/Themes/Startup.cs
+++ b/Themes/Startup.cs
@@ -13,7 +13,7 @@ namespace INZFS.Theme
             serviceCollection.AddScoped<IResourceManifestProvider, ResourceManifest>();
             serviceCollection.Configure<IdentityOptions>(options =>
             {
-                options.Password.RequireDigit = false;
+                options.Password.RequireDigit = true;
                 options.Password.RequireLowercase = true;
                 options.Password.RequireUppercase = true;
                 options.Password.RequireNonAlphanumeric = true;

--- a/Themes/Startup.cs
+++ b/Themes/Startup.cs
@@ -16,9 +16,9 @@ namespace INZFS.Theme
                 options.Password.RequireDigit = false;
                 options.Password.RequireLowercase = true;
                 options.Password.RequireUppercase = true;
-                options.Password.RequireNonAlphanumeric = false;
+                options.Password.RequireNonAlphanumeric = true;
                 options.Password.RequiredUniqueChars = 3;
-                options.Password.RequiredLength = 7;
+                options.Password.RequiredLength = 8;
             });
         }
     }


### PR DESCRIPTION
Adjusts password validation to meet AC for ticket 632. No need to directly compare against a list of known common passwords, as these criteria eliminate common passwords. 