### PR TITLE
Added new environment vars for referencing external media directory

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -25,3 +25,7 @@ applications:
     OrchardCore__OrchardCore_Shells_Azure__BasePath: $(BlobBasePath)
     OrchardCore__OrchardCore_Shells_Azure__MigrateFromFiles: True
     GovNotifyApiKey: $(GovNotifyApiKey)
+    OrchardCore__OrchardCore_Media_Azure__ConnectionString: $(AzureBlob)
+    OrchardCore__OrchardCore_Media_Azure__ContainerName: $(BlobDir)
+    OrchardCore__OrchardCore_Media_Azure__BasePath: $(BlobBasePath)
+    OrchardCore__OrchardCore_Media_Azure__CreateContainer: True


### PR DESCRIPTION
Fixes persistence issues with media files on re-deploy. Creating variables in manifest file and enabling Azure Media Storage feature on environments to reference media files from external blob storage.