### PR TITLE
Moving 2FA vars from appsettings to Environment variables. 

### DIFF
--- a/INZFS/Properties/launchSettings.json
+++ b/INZFS/Properties/launchSettings.json
@@ -31,7 +31,10 @@
         "OrchardCore__OrchardCore_AutoSetup__Tenants__0__SiteTimeZone": "Europe/London",
         "OrchardCore__OrchardCore_AutoSetup__Tenants__0__SiteName": "EEF",
         "OrchardCore__OrchardCore_AutoSetup__Tenants__0__DatabaseProvider": "Sqlite",
-        "OrchardCore__OrchardCore_AutoSetup__Tenants__0__AdminPassword": "TestUser!1"
+        "OrchardCore__OrchardCore_AutoSetup__Tenants__0__AdminPassword": "TestUser!1",
+        "TwoFactor__Status": "1",
+        "TwoFactor__AccountName": "INZFS-Dev",
+        "GovNotifyApiKey": ""
       },
       "dotnetRunMessages": "true",
       "applicationUrl": "https://localhost:5001;http://localhost:5000"

--- a/INZFS/appsettings.Development.json
+++ b/INZFS/appsettings.Development.json
@@ -11,9 +11,5 @@
   "AllowedHosts": "*",
   "ClamAVServerHost": "$(ClamAVServerHost)",
   "ClamAVServerPort": 3310,
-  "AzureBlobStorage": "$(AzureBlobStorage)",
-  "TwoFactor": {
-    "Status": 1, 
-    "AccountName": "INZFS-Dev"
-  }
+  "AzureBlobStorage": "$(AzureBlobStorage)"
 }

--- a/INZFS/appsettings.json
+++ b/INZFS/appsettings.json
@@ -28,9 +28,6 @@
   "ClamAVServerHost": "$(ClamAVServerHost)",
   "ClamAVServerPort": 3310,
   "AzureBlobStorage": "$(AzureBlobStorage)",
-  "MyRedisConStr": "$(MyRedisConStr)",
-  "TwoFactor": {
-    "Status": "$(2FA-Status)",
-    "AccountName": "INZFS-Dev"
-  }
+  "MyRedisConStr": "$(MyRedisConStr)"
+  
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -25,3 +25,5 @@ applications:
     OrchardCore__OrchardCore_Shells_Azure__BasePath: $(BlobBasePath)
     OrchardCore__OrchardCore_Shells_Azure__MigrateFromFiles: True
     GovNotifyApiKey: $(GovNotifyApiKey)
+    TwoFactor__Status: $(2FA-Status)
+    TwoFactor__AccountName: "INZFS-Dev"


### PR DESCRIPTION
Moving 2FA vars from appsettings to Environment variables to prevent issues with deployment as well as local build issues. 
Default on Develop is 1 = optional (Change in Launch settings to enable 0=Enabled, 2=disabled)