### PR TITLE
Fix Aspose Licensing Stream

### DIFF
--- a/INZFS.MVC/Services/PdfServices/ReportService.cs
+++ b/INZFS.MVC/Services/PdfServices/ReportService.cs
@@ -35,9 +35,8 @@ namespace INZFS.MVC.Services.PdfServices
             {
                 try
                 {
-                    MemoryStream stream = new MemoryStream(File.ReadAllBytes(lic.ToString()));
                     License license = new();
-                    license.SetLicense(stream);
+                    license.SetLicense(lic.ToStream());
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Streaming BinaryData directly, removing MemoryStream of stringified BinaryData