### PR TITLE
Remove equality data from summary

### DIFF
--- a/INZFS.MVC/Services/PdfServices/ReportService.cs
+++ b/INZFS.MVC/Services/PdfServices/ReportService.cs
@@ -195,7 +195,7 @@ namespace INZFS.MVC.Services.PdfServices
 
         private void PopulateHtmlSections(ApplicationContent applicationContent)
         {
-            foreach (var section in _applicationDefinition.Application.Sections)
+            foreach (var section in _applicationDefinition.Application.Sections) if (section.BelongsToApplication)
             {
                 string sectionHtml = $@"
                 <h2 style=""color:rgb(18,31,54);"", id=""{section.Tag}"" >{ section.OverviewTitle }</h2>


### PR DESCRIPTION
Using BelongsToApplication bool to remove confidential content from application summary