### PR TITLE
IN 1938 - red text is not easy to read in document 

### DIFF
--- a/INZFS.MVC/Services/PdfServices/ReportService.cs
+++ b/INZFS.MVC/Services/PdfServices/ReportService.cs
@@ -231,7 +231,7 @@ namespace INZFS.MVC.Services.PdfServices
 
             if (answer == null)
             {
-                return @"<span style=""color:red;"">No response</span>";
+                return @"<span>No response</span>";
             }
             else
             {


### PR DESCRIPTION
Accesiblity requirement - remove red text on white background for No Response