### PR TITLE
Bugfix uploaded filename save

### DIFF
--- a/INZFS.MVC/Controllers/FundApplicationController.cs
+++ b/INZFS.MVC/Controllers/FundApplicationController.cs
@@ -256,6 +256,8 @@ namespace INZFS.MVC.Controllers
                             Size = (file.Length / (double)Math.Pow(1024, 2)).ToString("0.00")
                         };
 
+                        model.UploadedFile = uploadedFile;
+
                         if (file.FileName.ToLower().Contains(".xlsx") && currentPage.Name == "project-cost-breakdown")
                         {
                             try
@@ -339,7 +341,6 @@ namespace INZFS.MVC.Controllers
                     else
                     {
                         var existingData = contentToSave.Fields.FirstOrDefault(f => f.Name.Equals(currentPage.FieldName));
-
                         //TODO - Handle validation Error
                         if (submitAction != "DeleteFile" && string.IsNullOrEmpty(existingData?.AdditionalInformation))
                         {
@@ -372,9 +373,14 @@ namespace INZFS.MVC.Controllers
                         // TODO Delete  the old file
 
                         bool fileHasChanged = additionalInformation != existingFieldData?.AdditionalInformation;
+                        if (!string.IsNullOrEmpty(existingFieldData?.AdditionalInformation))
+                        {
+                            model.UploadedFile = JsonSerializer.Deserialize<UploadedFile>(existingFieldData.AdditionalInformation);
+                        }
                         if ((fileHasChanged && !string.IsNullOrEmpty(existingFieldData?.AdditionalInformation)) || submitAction == "DeleteFile")
                         {
                             var uploadedFile = JsonSerializer.Deserialize<UploadedFile>(existingFieldData.AdditionalInformation);
+                            model.UploadedFile = uploadedFile;
                             var deleteSucessful = await _fileUploadService.DeleteFile(uploadedFile.FileLocation);
                             if(submitAction == "DeleteFile")
                             {

--- a/INZFS.MVC/Models/DynamicForm/BaseModel.cs
+++ b/INZFS.MVC/Models/DynamicForm/BaseModel.cs
@@ -28,6 +28,7 @@ namespace INZFS.MVC.Models.DynamicForm
         public string Section { get; set; }
         public TextType TextType { get; set; }
         public YesNoType YesNoInput { get; set; }
+        public UploadedFile UploadedFile { get; set; }
 
         public string AccordianReference { get; set; }
         public string DataInput { get; set; }

--- a/INZFS.MVC/Models/DynamicForm/FileUploadModel.cs
+++ b/INZFS.MVC/Models/DynamicForm/FileUploadModel.cs
@@ -10,10 +10,14 @@ namespace INZFS.MVC.Models.DynamicForm
 {
     public class FileUploadModel : BaseModel
     {
-        public UploadedFile UploadedFile { get; set; }
         protected override IEnumerable<ValidationResult> ExtendedValidation(ValidationContext validationContext)
         {
             return Enumerable.Empty<ValidationResult>();
+        }
+
+        public override string GetData()
+        {
+            return UploadedFile?.Name;
         }
     }
 }


### PR DESCRIPTION
Resolves an issue where an uploaded filename would only be saved at upload time, then overwritten with Null on the next save (eg moving to next page).